### PR TITLE
Switch to websocket client and initial support for State Query protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ xogmios-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+.DS_Store
+.iex.exs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![CI Status](https://github.com/wowica/xogmios/actions/workflows/ci.yml/badge.svg)
 
-An Elixir client for [Ogmios](https://github.com/CardanoSolutions/ogmios). This project is highly experimental. It currently only partially supports the chain sync Ouroboros mini-protocol.
+An Elixir client for Cardano's [Ogmios](https://github.com/CardanoSolutions/ogmios).
+
+Currently supports the **Chain Synchronization** and **State Query** Ouroboros mini-protocol.
 
 ## Installing
 
@@ -64,19 +66,20 @@ defmodule MyApp.ChainSyncClient do
 
   require Logger
 
-  def start_link(opts),
-    do: start_connection(opts)
+  def start_link(opts) do
+    # Initial state currently has to be defined here
+    # and passed as argument to start_connection
+    initial_state = [counter: 3]
 
-  @impl true
-  def init(_args) do
-    {:ok, %{counter: 3}}
+    opts
+    |> Keyword.merge(initial_state)
+    |> start_connection()
   end
 
   @impl true
   def handle_block(block, %{counter: counter} = state) when counter > 1 do
     Logger.info("handle_block #{block["height"]}")
-    new_state = Map.merge(state, %{counter: counter - 1})
-    {:ok, :next_block, new_state}
+    {:ok, :next_block, %{state | counter: counter - 1}}
   end
 
   @impl true
@@ -86,6 +89,8 @@ defmodule MyApp.ChainSyncClient do
   end
 end
 ```
+
+See more examples in the [examples](./examples/) folder.
 
 ## Test
 

--- a/examples/chain_sync_client.ex
+++ b/examples/chain_sync_client.ex
@@ -1,0 +1,25 @@
+defmodule ChainSyncClient do
+  @moduledoc """
+  This module syncs with the tip of the chain and reads blocks indefinitely.
+
+  Add this to your application's supervision tree like so:
+
+  def start(_type, _args) do
+    children = [
+      {ChainSyncClient, url: "ws://..."},
+    ]
+    ...
+  end
+  """
+
+  use Xogmios.ChainSync
+
+  def start_link(opts),
+    do: start_connection(opts)
+
+  @impl true
+  def handle_block(block, state) do
+    IO.puts("handle_block from client #{block["height"]}")
+    {:ok, :next_block, state}
+  end
+end

--- a/examples/state_query_client.ex
+++ b/examples/state_query_client.ex
@@ -1,0 +1,38 @@
+defmodule StateQueryClient do
+  @moduledoc """
+  This module queries against the known tip of the chain.
+
+  Add this to your application's supervision tree like so:
+
+  def start(_type, _args) do
+    children = [
+      {StateQueryClient, url: "ws://..."},
+    ]
+    ...
+  end
+
+  Then invoke functions:
+   * StateQueryClient.get_current_epoch()
+   * StateQueryClient.get_era_start()
+
+  Not all queries are supported yet.
+  """
+  use Xogmios.StateQuery
+
+  def start_link(opts),
+    do: start_connection(opts)
+
+  def get_current_epoch() do
+    case send_query(:get_current_epoch) do
+      {:ok, result} -> result
+      {:error, reason} -> "Something went wrong #{inspect(reason)}"
+    end
+  end
+
+  def get_era_start() do
+    case send_query(:era_start) do
+      {:ok, result} -> result
+      {:error, reason} -> "Something went wrong #{inspect(reason)}"
+    end
+  end
+end

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -1,7 +1,11 @@
 defmodule Xogmios.ChainSync do
-  alias Xogmios.ChainSync.Messages
+  @moduledoc """
+  This module interfaces with the Chain Synchronization protocol.
+  """
 
   require Logger
+
+  alias Xogmios.ChainSync.Messages
 
   @callback handle_block(map(), any()) ::
               {:ok, :next_block, map()} | {:ok, map()} | {:ok, :close, map()}
@@ -9,8 +13,11 @@ defmodule Xogmios.ChainSync do
   defmacro __using__(_opts) do
     quote do
       @behaviour Xogmios.ChainSync
-      use Xogmios.Connection, :chain_sync
+
+      use Xogmios.ChainSync.Connection
+
       require Logger
+
       @name __MODULE__
 
       def handle_message(%{"id" => "start"} = message, state) do

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -26,7 +26,6 @@ defmodule Xogmios.ChainSync do
           "result" => %{"direction" => "backward", "tip" => tip}
         } = message
 
-        # Logger.debug("id start")
         message = Messages.find_intersection(tip["slot"], tip["id"])
         {:reply, {:text, message}, state}
       end
@@ -48,8 +47,6 @@ defmodule Xogmios.ChainSync do
             %{"method" => "nextBlock", "result" => %{"direction" => "forward"} = result},
             state
           ) do
-        # Logger.info("handle_block #{result["block"]["height"]}")
-
         case state.handler.handle_block(result["block"], state) do
           {:ok, :next_block, new_state} ->
             message = Messages.next_block()
@@ -59,7 +56,7 @@ defmodule Xogmios.ChainSync do
             {:ok, new_state}
 
           {:ok, :close, new_state} ->
-            {:close, new_state}
+            {:close, "finished", new_state}
 
           response ->
             Logger.warning("Invalid response #{inspect(response)}")

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -9,69 +9,9 @@ defmodule Xogmios.ChainSync do
   defmacro __using__(_opts) do
     quote do
       @behaviour Xogmios.ChainSync
-      @behaviour :websocket_client
+      use Xogmios.Connection, :chain_sync
       require Logger
       @name __MODULE__
-
-      def child_spec(opts) do
-        %{
-          id: __MODULE__,
-          start: {__MODULE__, :start_link, [opts]},
-          shutdown: 5_000,
-          restart: Keyword.get(opts, :restart, :transient),
-          type: :worker
-        }
-      end
-
-      def init([%{handler: handler}]) do
-        Logger.debug("Xogmios.ChainSync init")
-        {:once, %{handler: handler}}
-      end
-
-      defoverridable init: 1
-
-      def start_connection(opts),
-        do: do_start_link(opts)
-
-      def do_start_link(opts) do
-        url = Keyword.get(opts, :url, "ws://192.168.1.11:1339")
-        state = %{handler: __MODULE__}
-        IO.inspect("state: #{inspect(state)}")
-        :websocket_client.start_link(url, __MODULE__, [state])
-      end
-
-      def onconnect(_arg0, state) do
-        Logger.debug("on connect")
-        message = Messages.next_block_start()
-        :websocket_client.cast(self(), {:text, message})
-        {:ok, state}
-      end
-
-      def start_sync(pid) do
-        message = Messages.next_block_start()
-        :websocket_client.cast(pid, {:text, message})
-      end
-
-      def ondisconnect(_reason, state) do
-        Logger.debug("on disconnect")
-        {:ok, state}
-      end
-
-      def websocket_handle({:text, raw_message}, _conn, state) do
-        case Jason.decode(raw_message) do
-          {:ok, message} ->
-            handle_message(message, state)
-
-          {:error, reason} ->
-            Logger.warning("Error decoding message #{inspect(reason)}")
-            {:ok, state}
-        end
-      end
-
-      def websocket_handle(_message, _conn, state) do
-        # Logger.debug("raw_message #{inspect(message)}")
-        {:ok, state}
-      end
 
       def handle_message(%{"id" => "start"} = message, state) do
         %{
@@ -79,7 +19,7 @@ defmodule Xogmios.ChainSync do
           "result" => %{"direction" => "backward", "tip" => tip}
         } = message
 
-        Logger.debug("id start")
+        # Logger.debug("id start")
         message = Messages.find_intersection(tip["slot"], tip["id"])
         {:reply, {:text, message}, state}
       end
@@ -101,7 +41,7 @@ defmodule Xogmios.ChainSync do
             %{"method" => "nextBlock", "result" => %{"direction" => "forward"} = result},
             state
           ) do
-        Logger.info("handle_block #{result["block"]["height"]}")
+        # Logger.info("handle_block #{result["block"]["height"]}")
 
         case state.handler.handle_block(result["block"], state) do
           {:ok, :next_block, new_state} ->
@@ -120,25 +60,9 @@ defmodule Xogmios.ChainSync do
       end
 
       def handle_message({:text, message}, state) do
-        Logger.info("fallback handle message #{inspect(message)}")
+        # Logger.info("fallback handle message #{inspect(message)}")
         {:close, state}
-      end
-
-      def websocket_info(_any, _arg1, state) do
-        Logger.info("websocket_info")
-        {:ok, state}
-      end
-
-      def websocket_terminate(_arg0, _arg1, _state) do
-        Logger.info("websocket_terminate")
-        :ok
       end
     end
   end
 end
-
-# cast(Client, Frame) ->
-#   gen_statem:cast(Client, {cast_frame, Frame}).
-
-# send(Client, Frame) ->
-#   gen_statem:call(Client, {send, Frame}).

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -29,13 +29,18 @@ defmodule Xogmios.ChainSync.Connection do
 
       def do_start_link(opts) do
         url = Keyword.fetch!(opts, :url)
-        state = %{handler: __MODULE__}
-        :websocket_client.start_link(url, __MODULE__, [state])
+
+        initial_state =
+          opts
+          |> Enum.into(%{})
+          |> Map.merge(%{handler: __MODULE__})
+
+        :websocket_client.start_link(url, __MODULE__, initial_state)
       end
 
       @impl true
-      def init([%{handler: handler}]) do
-        {:once, %{handler: handler}}
+      def init(initial_state) do
+        {:once, initial_state}
       end
 
       @impl true

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -30,16 +30,18 @@ defmodule Xogmios.ChainSync.Connection do
       def do_start_link(opts) do
         url = Keyword.fetch!(opts, :url)
 
-        initial_state =
-          opts
-          |> Enum.into(%{})
-          |> Map.merge(%{handler: __MODULE__})
+        state = Keyword.merge(opts, handler: __MODULE__)
 
-        :websocket_client.start_link(url, __MODULE__, initial_state)
+        :websocket_client.start_link(url, __MODULE__, state)
       end
 
       @impl true
-      def init(initial_state) do
+      def init(state) do
+        initial_state =
+          state
+          |> Enum.into(%{})
+          |> Map.merge(%{handler: __MODULE__})
+
         {:once, initial_state}
       end
 

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -1,22 +1,18 @@
-defmodule Xogmios.Connection do
+defmodule Xogmios.ChainSync.Connection do
   @moduledoc """
-  This module implements the connection with the Ogmios Websocket server.
+  This module implements a connection with the Ogmios Websocket server
+  for the Chain Synchronization protocol.
   """
 
-  @start_messages %{
-    chain_sync: Xogmios.ChainSync.Messages.next_block_start()
-  }
+  alias Xogmios.ChainSync.Messages
 
-  @spec start_messages() :: map()
-  def start_messages, do: @start_messages
-
-  defmacro __using__(ouroboros_protocol) do
+  defmacro __using__(_opts) do
     quote do
       @behaviour :websocket_client
 
-      @name __MODULE__
-
       require Logger
+
+      @name __MODULE__
 
       def child_spec(opts) do
         %{
@@ -28,13 +24,6 @@ defmodule Xogmios.Connection do
         }
       end
 
-      def init([%{handler: handler}]) do
-        # Logger.debug("Xogmios.ChainSync init")
-        {:once, %{handler: handler}}
-      end
-
-      defoverridable init: 1
-
       def start_connection(opts),
         do: do_start_link(opts)
 
@@ -44,26 +33,24 @@ defmodule Xogmios.Connection do
         :websocket_client.start_link(url, __MODULE__, [state])
       end
 
-      def onconnect(_arg0, state) do
-        # Logger.debug("on connect")
-        start_message = get_start_message()
-        :websocket_client.cast(self(), {:text, get_start_message()})
+      @impl true
+      def init([%{handler: handler}]) do
+        {:once, %{handler: handler}}
+      end
+
+      @impl true
+      def onconnect(_arg, state) do
+        start_message = Messages.next_block_start()
+        :websocket_client.cast(self(), {:text, start_message})
         {:ok, state}
       end
 
-      defp get_start_message do
-        # Each mini-protocol (chain sync, local state query, etc.)
-        # requires a different start message to begin communication
-        # with the server
-        protocol = unquote(ouroboros_protocol)
-        Map.get(Xogmios.Connection.start_messages(), protocol)
-      end
-
+      @impl true
       def ondisconnect(_reason, state) do
-        # Logger.debug("on disconnect")
         {:ok, state}
       end
 
+      @impl true
       def websocket_handle({:text, raw_message}, _conn, state) do
         case Jason.decode(raw_message) do
           {:ok, message} ->
@@ -75,18 +62,18 @@ defmodule Xogmios.Connection do
         end
       end
 
+      @impl true
       def websocket_handle(_message, _conn, state) do
-        # Logger.debug("raw_message #{inspect(message)}")
         {:ok, state}
       end
 
+      @impl true
       def websocket_info(_any, _arg1, state) do
-        # Logger.info("websocket_info")
         {:ok, state}
       end
 
+      @impl true
       def websocket_terminate(_arg0, _arg1, _state) do
-        # Logger.info("websocket_terminate")
         :ok
       end
     end

--- a/lib/xogmios/chain_sync/messages.ex
+++ b/lib/xogmios/chain_sync/messages.ex
@@ -1,29 +1,37 @@
 defmodule Xogmios.ChainSync.Messages do
   @moduledoc """
-  This module returns messages according to the Ogmios API
+  This module returns messages for the Chain Synchronization protocol
   """
 
+  alias Jason.DecodeError
+
   def next_block_start() do
-    ~S"""
+    json = ~S"""
     {
       "jsonrpc": "2.0",
       "method": "nextBlock",
       "id": "start"
     }
     """
+
+    validate_json!(json)
+    json
   end
 
   def next_block() do
-    ~S"""
+    json = ~S"""
     {
       "jsonrpc": "2.0",
       "method": "nextBlock"
     }
     """
+
+    validate_json!(json)
+    json
   end
 
   def find_intersection(slot, id) do
-    ~s"""
+    json = ~s"""
     {
       "jsonrpc": "2.0",
       "method": "findIntersection",
@@ -37,5 +45,15 @@ defmodule Xogmios.ChainSync.Messages do
       }
     }
     """
+
+    validate_json!(json)
+    json
+  end
+
+  defp validate_json!(json) do
+    case Jason.decode(json) do
+      {:ok, _decoded} -> :ok
+      {:error, %DecodeError{} = error} -> raise "Invalid JSON: #{inspect(error)}"
+    end
   end
 end

--- a/lib/xogmios/connection.ex
+++ b/lib/xogmios/connection.ex
@@ -1,0 +1,94 @@
+defmodule Xogmios.Connection do
+  @moduledoc """
+  This module implements the connection with the Ogmios Websocket server.
+  """
+
+  @start_messages %{
+    chain_sync: Xogmios.ChainSync.Messages.next_block_start()
+  }
+
+  @spec start_messages() :: map()
+  def start_messages, do: @start_messages
+
+  defmacro __using__(ouroboros_protocol) do
+    quote do
+      @behaviour :websocket_client
+
+      @name __MODULE__
+
+      require Logger
+
+      def child_spec(opts) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [opts]},
+          shutdown: 5_000,
+          restart: Keyword.get(opts, :restart, :transient),
+          type: :worker
+        }
+      end
+
+      def init([%{handler: handler}]) do
+        # Logger.debug("Xogmios.ChainSync init")
+        {:once, %{handler: handler}}
+      end
+
+      defoverridable init: 1
+
+      def start_connection(opts),
+        do: do_start_link(opts)
+
+      def do_start_link(opts) do
+        url = Keyword.fetch!(opts, :url)
+        state = %{handler: __MODULE__}
+        :websocket_client.start_link(url, __MODULE__, [state])
+      end
+
+      def onconnect(_arg0, state) do
+        # Logger.debug("on connect")
+        start_message = get_start_message()
+        :websocket_client.cast(self(), {:text, get_start_message()})
+        {:ok, state}
+      end
+
+      defp get_start_message do
+        # Each mini-protocol (chain sync, local state query, etc.)
+        # requires a different start message to begin communication
+        # with the server
+        protocol = unquote(ouroboros_protocol)
+        Map.get(Xogmios.Connection.start_messages(), protocol)
+      end
+
+      def ondisconnect(_reason, state) do
+        # Logger.debug("on disconnect")
+        {:ok, state}
+      end
+
+      def websocket_handle({:text, raw_message}, _conn, state) do
+        case Jason.decode(raw_message) do
+          {:ok, message} ->
+            handle_message(message, state)
+
+          {:error, reason} ->
+            Logger.warning("Error decoding message #{inspect(reason)}")
+            {:ok, state}
+        end
+      end
+
+      def websocket_handle(_message, _conn, state) do
+        # Logger.debug("raw_message #{inspect(message)}")
+        {:ok, state}
+      end
+
+      def websocket_info(_any, _arg1, state) do
+        # Logger.info("websocket_info")
+        {:ok, state}
+      end
+
+      def websocket_terminate(_arg0, _arg1, _state) do
+        # Logger.info("websocket_terminate")
+        :ok
+      end
+    end
+  end
+end

--- a/lib/xogmios/state_query.ex
+++ b/lib/xogmios/state_query.ex
@@ -1,0 +1,71 @@
+defmodule Xogmios.StateQuery do
+  @moduledoc """
+  This module interfaces with the State Query protocol.
+  """
+
+  alias Xogmios.StateQuery
+  alias Xogmios.StateQuery.Messages
+  alias Xogmios.StateQuery.Response
+  alias Xogmios.StateQuery.Server
+
+  @allowed_queries [:get_current_epoch, :get_era_start]
+
+  @query_messages %{
+    get_current_epoch: Messages.get_current_epoch(),
+    get_era_start: Messages.get_era_start()
+  }
+
+  def allowed_queries, do: @allowed_queries
+  def query_messages, do: @query_messages
+
+  defmacro __using__(_opts) do
+    quote do
+      use GenServer
+
+      ## Client API
+
+      @doc """
+      Sends a State Query call to the server and returns a response.
+      This function is synchornous.
+      """
+      @spec send_query(term(), term()) :: {:ok, any()} | {:error, any()}
+      def send_query(client \\ __MODULE__, query) do
+        with {:ok, message} <- Map.fetch(StateQuery.query_messages(), query),
+             {:ok, %Response{} = response} <- GenServer.call(client, {:send_message, message}) do
+          {:ok, response.result}
+        else
+          :error -> {:error, "Unsupported query"}
+          {:error, _reason} -> {:error, "Error sending query"}
+        end
+      end
+
+      def start_connection(opts),
+        do: do_start_link(opts)
+
+      def do_start_link(args),
+        do: GenServer.start_link(__MODULE__, args, name: __MODULE__)
+
+      ## Callbacks
+
+      @impl true
+      def init(args) do
+        url = Keyword.fetch!(args, :url)
+
+        case :websocket_client.start_link(url, Server, []) do
+          {:ok, ws_pid} ->
+            {:ok, %{ws_pid: ws_pid, response: nil, caller: nil}}
+
+          {:error, _} = error ->
+            error
+        end
+      end
+
+      @impl true
+      def handle_call({:send_message, message}, from, state) do
+        send(state.ws_pid, {:store_caller, from})
+        :ok = :websocket_client.send(state.ws_pid, {:text, message})
+        {:noreply, state}
+      end
+    end
+  end
+end

--- a/lib/xogmios/state_query.ex
+++ b/lib/xogmios/state_query.ex
@@ -8,14 +8,11 @@ defmodule Xogmios.StateQuery do
   alias Xogmios.StateQuery.Response
   alias Xogmios.StateQuery.Server
 
-  @allowed_queries [:get_current_epoch, :get_era_start]
-
   @query_messages %{
     get_current_epoch: Messages.get_current_epoch(),
     get_era_start: Messages.get_era_start()
   }
 
-  def allowed_queries, do: @allowed_queries
   def query_messages, do: @query_messages
 
   defmacro __using__(_opts) do

--- a/lib/xogmios/state_query/messages.ex
+++ b/lib/xogmios/state_query/messages.ex
@@ -1,0 +1,77 @@
+defmodule Xogmios.StateQuery.Messages do
+  @moduledoc """
+  This module returns messages for the State Query protocol
+  """
+
+  alias Jason.DecodeError
+
+  @doc """
+  Returns point to be used by acquire_ledger_state/1
+  """
+  def get_tip do
+    json = ~S"""
+    {
+      "jsonrpc": "2.0",
+      "method": "queryNetwork/tip"
+    }
+    """
+
+    validate_json!(json)
+    json
+  end
+
+  @doc """
+  Acquires ledger state to be used by subsequent queries
+  """
+  def acquire_ledger_state(%{"slot" => slot, "id" => id} = _point) do
+    json = ~s"""
+    {
+      "jsonrpc": "2.0",
+      "method": "acquireLedgerState",
+      "params": {
+          "point": {
+              "slot": #{slot},
+              "id": "#{id}"
+          }
+      }
+    }
+    """
+
+    validate_json!(json)
+    json
+  end
+
+  @doc """
+  Returns current epoch
+  """
+  def get_current_epoch do
+    json = ~S"""
+    {
+      "jsonrpc": "2.0",
+      "method": "queryLedgerState/epoch"
+    }
+    """
+
+    validate_json!(json)
+    json
+  end
+
+  def get_era_start do
+    json = ~S"""
+    {
+      "jsonrpc": "2.0",
+      "method": "queryLedgerState/eraStart"
+    }
+    """
+
+    validate_json!(json)
+    json
+  end
+
+  defp validate_json!(json) do
+    case Jason.decode(json) do
+      {:ok, _decoded} -> :ok
+      {:error, %DecodeError{} = error} -> raise "Invalid JSON: #{inspect(error)}"
+    end
+  end
+end

--- a/lib/xogmios/state_query/response.ex
+++ b/lib/xogmios/state_query/response.ex
@@ -1,0 +1,3 @@
+defmodule Xogmios.StateQuery.Response do
+  defstruct [:result]
+end

--- a/lib/xogmios/state_query/response.ex
+++ b/lib/xogmios/state_query/response.ex
@@ -1,3 +1,7 @@
 defmodule Xogmios.StateQuery.Response do
+  @moduledoc """
+  This module provides a common interface for responses from a State Queries
+  """
+
   defstruct [:result]
 end

--- a/lib/xogmios/state_query/server.ex
+++ b/lib/xogmios/state_query/server.ex
@@ -1,0 +1,93 @@
+defmodule Xogmios.StateQuery.Server do
+  @moduledoc """
+  This module implements the callbacks necessary for receiving asynchronous responses from
+  the WebSocket server. It acts as an synchronous interface for clients of Xogmios.StateQuery.
+  It uses GenServer.reply/2 to respond to GenServer.call/2 calls from Xogmios.StateQuery.send_query/2.
+  """
+
+  @behaviour :websocket_client
+
+  require Logger
+
+  alias Xogmios.StateQuery.Messages
+  alias Xogmios.StateQuery.Response
+
+  defp handle_message(
+         %{"method" => "queryNetwork/tip"} = message,
+         state
+       ) do
+    point = message["result"]
+    message = Messages.acquire_ledger_state(point)
+    {:reply, {:text, message}, state}
+  end
+
+  defp handle_message(
+         %{"method" => "acquireLedgerState"} = _message,
+         state
+       ) do
+    {:ok, state}
+  end
+
+  defp handle_message(
+         %{"method" => _method, "result" => result},
+         state
+       ) do
+    GenServer.reply(state.caller, {:ok, %Response{result: result}})
+    {:ok, state}
+  end
+
+  defp handle_message(_message, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def init(_args) do
+    {:once, %{caller: nil}}
+  end
+
+  @impl true
+  def onconnect(_arg0, state) do
+    start_message = Xogmios.StateQuery.Messages.get_tip()
+    :websocket_client.cast(self(), {:text, start_message})
+    {:ok, state}
+  end
+
+  @impl true
+  def ondisconnect(_reason, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def websocket_handle({:text, raw_message}, _conn, state) do
+    case Jason.decode(raw_message) do
+      {:ok, message} ->
+        handle_message(message, state)
+
+      {:error, reason} ->
+        Logger.warning("Error decoding message #{inspect(reason)}")
+        {:ok, state}
+    end
+  end
+
+  @impl true
+  def websocket_handle(_message, _conn, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def websocket_info({:store_caller, caller}, _req, state) do
+    # Stores caller of the query so that GenServer.reply knows
+    # who to return the response to
+    {:ok, %{state | caller: caller}}
+  end
+
+  @impl true
+  def websocket_info(_any, _arg1, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def websocket_terminate(_arg0, _arg1, _state) do
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Xogmios.MixProject do
       {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false},
       {:plug, "~> 1.15", only: :test},
       {:plug_cowboy, "~> 2.6", only: :test},
-      {:websockex, "~> 0.4.3"}
+      {:websocket_client, "~> 1.5"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "plug_crypto": {:hex, :plug_crypto, "2.0.0", "77515cc10af06645abbfb5e6ad7a3e9714f805ae118fa1a70205f80d2d70fe73", [:mix], [], "hexpm", "53695bae57cc4e54566d993eb01074e4d894b65a3766f1c43e2c61a1b0f45ea9"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
-  "websockex": {:hex, :websockex, "0.4.3", "92b7905769c79c6480c02daacaca2ddd49de936d912976a4d3c923723b647bf0", [:mix], [], "hexpm", "95f2e7072b85a3a4cc385602d42115b73ce0b74a9121d0d6dbbf557645ac53e4"},
+  "websocket_client": {:hex, :websocket_client, "1.5.0", "e825f23c51a867681a222148ed5200cc4a12e4fb5ff0b0b35963e916e2b5766b", [:rebar3], [], "hexpm", "2b9b201cc5c82b9d4e6966ad8e605832eab8f4ddb39f57ac62f34cb208b68de9"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.9.0", "9a256da867b37b8d2c1ffd5d9de373a4fda77a32a45b452f1708508ba7bbcb53", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "0cb0e7d4c56f5e99a6253ed1a670ed0e39c13fc45a6da054033928607ac08dfc"},
 }

--- a/test/xogmios_test.exs
+++ b/test/xogmios_test.exs
@@ -20,36 +20,23 @@ defmodule XogmiosTest do
       do: start_connection(opts)
 
     @impl true
-    def init(opts) do
-      target = Keyword.get(opts, :target)
-      {:ok, %{target: target}}
-    end
-
-    @impl true
     def handle_block(_block, state) do
-      send(state.target, :handle_block)
+      send(state.test_handler, :handle_block)
       {:ok, :close, state}
-    end
-
-    @impl true
-    def terminate(_reason, state) do
-      send(state.target, :terminate)
-      :ok
     end
   end
 
   test "receives handle block" do
-    pid = start_supervised!({DummyClient, url: @ws_url, target: self()})
+    pid = start_supervised!({DummyClient, url: @ws_url, test_handler: self()})
     assert is_pid(pid)
     assert_receive :handle_block
   end
 
   test "terminates process when connection is closed" do
-    pid = start_supervised!({DummyClient, url: @ws_url, target: self()})
+    pid = start_supervised!({DummyClient, url: @ws_url, test_handler: self()})
     assert is_pid(pid)
-    Process.sleep(1000)
+    Process.sleep(500)
     refute Process.alive?(pid)
     assert GenServer.whereis(DummyClient) == nil
-    assert_receive :terminate
   end
 end


### PR DESCRIPTION
Replace `websockex` with `websocket_client` as the websocket library dependency. The latter proved to be easier to work with for adding support for a synchronous API for State Queries.