### PR TITLE
Add sync_from option

### DIFF
--- a/examples/chain_sync_client.ex
+++ b/examples/chain_sync_client.ex
@@ -17,6 +17,17 @@ defmodule ChainSyncClient do
 
   def start_link(opts) do
     initial_state = [counter: 3]
+    ### See examples below on how to sync
+    ### from different points of the chain:
+    # initial_state = [sync_from: :babbage]
+    # initial_state = [
+    #   sync_from: %{
+    #     point: %{
+    #       slot: 114_127_654,
+    #       id: "b0ff1e2bfc326a7f7378694b1f2693233058032bfb2798be2992a0db8b143099"
+    #     }
+    #   }
+    # ]
     opts = Keyword.merge(opts, initial_state)
     Xogmios.start_chain_sync_link(__MODULE__, opts)
   end

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -42,7 +42,7 @@ defmodule Xogmios.ChainSync.Connection do
       end
 
       @impl true
-      def ondisconnect(reason, state) do
+      def ondisconnect(_reason, state) do
         {:ok, state}
       end
 
@@ -70,7 +70,6 @@ defmodule Xogmios.ChainSync.Connection do
 
       @impl true
       def websocket_terminate(_arg0, _arg1, _state) do
-        IO.puts("websocket_terminate")
         :ok
       end
     end

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -36,7 +36,6 @@ defmodule Xogmios.ChainSync.Connection do
 
       @impl true
       def onconnect(_arg, state) do
-        IO.puts("onconnect")
         start_message = Messages.next_block_start()
         :websocket_client.cast(self(), {:text, start_message})
         {:ok, state}
@@ -44,8 +43,7 @@ defmodule Xogmios.ChainSync.Connection do
 
       @impl true
       def ondisconnect(reason, state) do
-        IO.puts("ondisconnect #{inspect(reason)}")
-        {:reconnect, 5_000, state}
+        {:ok, state}
       end
 
       @impl true

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -31,19 +31,21 @@ defmodule Xogmios.ChainSync.Connection do
           |> Enum.into(%{})
           |> Map.merge(%{handler: __MODULE__})
 
-        {:once, initial_state}
+        {:reconnect, initial_state}
       end
 
       @impl true
       def onconnect(_arg, state) do
+        IO.puts("onconnect")
         start_message = Messages.next_block_start()
         :websocket_client.cast(self(), {:text, start_message})
         {:ok, state}
       end
 
       @impl true
-      def ondisconnect(_reason, state) do
-        {:ok, state}
+      def ondisconnect(reason, state) do
+        IO.puts("ondisconnect #{inspect(reason)}")
+        {:reconnect, 5_000, state}
       end
 
       @impl true
@@ -70,6 +72,7 @@ defmodule Xogmios.ChainSync.Connection do
 
       @impl true
       def websocket_terminate(_arg0, _arg1, _state) do
+        IO.puts("websocket_terminate")
         :ok
       end
     end

--- a/lib/xogmios/chain_sync/messages.ex
+++ b/lib/xogmios/chain_sync/messages.ex
@@ -50,6 +50,47 @@ defmodule Xogmios.ChainSync.Messages do
     json
   end
 
+  def find_origin do
+    # For finding origin, any value can be passed as a point as long as "origin"
+    # is the first value.
+    json = ~S"""
+    {
+      "jsonrpc": "2.0",
+      "method": "findIntersection",
+      "params": {
+          "points": [
+            "origin",
+            {
+              "slot": 4492799,
+              "id": "f8084c61b6a238acec985b59310b6ecec49c0ab8352249afd7268da5cff2a457"
+            }
+          ]
+      }
+    }
+    """
+
+    validate_json!(json)
+    json
+  end
+
+  # The following are the last points (absolute slot and block id) of
+  # the previous era of each entry. The sync is done against the last
+  # point, so that the next block received is the first of the following era.
+  @era_bounds %{
+    shelley: {4_492_799, "f8084c61b6a238acec985b59310b6ecec49c0ab8352249afd7268da5cff2a457"},
+    allegra: {16_588_737, "4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a"},
+    mary: {23_068_793, "4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a"},
+    alonzo: {39_916_796, "e72579ff89dc9ed325b723a33624b596c08141c7bd573ecfff56a1f7229e4d09"},
+    babbage: {72_316_796, "c58a24ba8203e7629422a24d9dc68ce2ed495420bf40d9dab124373655161a20"}
+  }
+
+  def last_block_from(era_name) when is_atom(era_name) do
+    case @era_bounds[era_name] do
+      {last_slot, last_block_id} -> find_intersection(last_slot, last_block_id)
+      nil -> {:error, :unknown_block}
+    end
+  end
+
   defp validate_json!(json) do
     case Jason.decode(json) do
       {:ok, _decoded} -> :ok


### PR DESCRIPTION
1. Allows syncing from a particular point in the chain.

```elixir
def start_link(opts) do
  # initial_state = [sync_from: :babbage]
  # initial_state = [sync_from: :origin]
  initial_state = [
    sync_from: %{
      point: %{
        slot: 114_127_654,
        id: "b0ff1e2bfc326a7f7378694b1f2693233058032bfb2798be2992a0db8b143099"
      }
    }
  ]

  opts = Keyword.merge(opts, initial_state)
  Xogmios.start_chain_sync_link(__MODULE__, opts)
end
```

2. Fixes a bug where the client would suddenly disconnect. By returning `{:reconnect, initial_state}` from `init/1` it appears to fix the bug.