### PR TITLE
Add tip to handle_block argument

### DIFF
--- a/test/support/chain_sync/test_handler.ex
+++ b/test/support/chain_sync/test_handler.ex
@@ -22,7 +22,11 @@ defmodule ChainSync.TestHandler do
         payload =
           Jason.encode!(%{
             "method" => "nextBlock",
-            "result" => %{"direction" => "forward", "block" => %{"height" => 123}}
+            "result" => %{
+              "direction" => "forward",
+              "block" => %{"height" => 123},
+              "tip" => %{"id" => "abc123", "slot" => 123}
+            }
           })
 
         Process.put(:counter, current_counter + 1)
@@ -43,7 +47,8 @@ defmodule ChainSync.TestHandler do
               "method" => "nextBlock",
               "result" => %{
                 "direction" => "forward",
-                "block" => %{"height" => 456}
+                "block" => %{"height" => 456},
+                "tip" => %{"id" => "abc123", "slot" => 123}
               }
             })
           end


### PR DESCRIPTION
Add current tip to the block to allow calculating chainsync duration. Adding this to the existing block for now to avoid breaking changes but we should consider implementing a new callback such as `handle_forward` to better handle a new top level entity with both "block" and "tip" as properties