### PR TITLE
Add ChainSync.call/2 for synchronous message passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New `Xogmios.ChainSync.call/2` function to send synchronous messages to the ChainSync process. Example:
+- New `Xogmios.ChainSync.call/2` function to send synchronous messages to the ChainSync process and an accompanying `handle_info/2` callback. Example usage of both:
 
   ```elixir
   defmodule ChainSyncBlockCounter do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Current tip information is now included in the block data passed to `handle_block/2` under the `current_tip` key. This allows clients to calculate the time needed for chainsync to sync from the current position. Adding this to the existing block for now to quickly enable other features, but we should consider implementing a new callback (like `handle_forward/2`) to better handle a new top level entity with both "block" and "tip" as properties.
+- Current tip information is now included in the block data passed to `handle_block/2` under the `current_tip` key. This allows clients to calculate the time needed for chainsync to sync from the current position. Adding this to the existing block for now to quickly enable other features, but we should consider implementing a new callback (like `handle_forward/2`) to better handle a new top level entity with both "block" and "tip" as properties. Example of a match for when the client is synced with the current tip (note the repeating `slot` variable name):
+
+```elixir
+@impl true
+def handle_block(
+  %{
+    "slot" => slot,
+    "current_tip" => %{"slot" => slot},
+  } = block,
+  state
+) do
+  # ... process the block
+  {:ok, :next_block, state}
+end
+```
 
 - New syntax for setting an intersection point on `ChainSync`:
 
@@ -30,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     point: %{slot: slot, id: block_hash}
   }
   ```
+### Removed
+
+- Removed `read_next_block/1` function from ChainSync. This function was a failed attempt at sending synchronous messages to ChainSync.
 
 ## [v0.6.1](https://github.com/wowica/xogmios/releases/tag/v0.6.1) (2024-12-22)
 

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -182,8 +182,8 @@ defmodule Xogmios.ChainSync do
         Logger.error("Process not found")
         error
 
-      error ->
-        Logger.error("Error building process name: #{inspect(error)}")
+      {:error, :invalid_process_name} = error ->
+        Logger.error("Invalid process name: #{inspect(error)}")
         error
     end
   end

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -179,11 +179,11 @@ defmodule Xogmios.ChainSync do
       {:ok, pid}
     else
       {:error, :process_not_found} = error ->
-        Logger.debug("Process not found")
+        Logger.error("Process not found")
         error
 
       error ->
-        Logger.debug("Error building process name: #{inspect(error)}")
+        Logger.error("Error building process name: #{inspect(error)}")
         error
     end
   end

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -138,9 +138,9 @@ defmodule Xogmios.ChainSync do
           5_000 -> {:error, :timeout}
         end
 
-      error ->
+      {:error, error} ->
         Logger.error("Error finding ChainSync process: #{inspect(error)}")
-        error
+        {:error, error}
     end
   end
 

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -71,6 +71,19 @@ defmodule Xogmios.ChainSync do
               | {:ok, new_state}
             when reason: String.t(), state: term(), new_state: term()
 
+  @doc """
+  Invoked when a message is sent to the process. This callback is optional.
+
+  Return type is the same as `c:handle_block/2` and `c:handle_rollback/2`.
+  """
+  @callback handle_info(message :: term(), state) ::
+              {:ok, :next_block, new_state}
+              | {:ok, new_state}
+              | {:close, new_state}
+            when state: term(), new_state: term()
+
+  @optional_callbacks handle_info: 2
+
   # The keepalive option is used to maintain the connection active.
   # This is important because proxies might close idle connections after a few seconds.
   @keepalive_in_ms 5_000

--- a/test/chain_sync_test.exs
+++ b/test/chain_sync_test.exs
@@ -313,6 +313,13 @@ defmodule Xogmios.ChainSyncTest do
       assert {:ok, "test_response"} = Xogmios.ChainSync.call(:named_call_test, :test_message)
     end
 
+    test "handles invalid process name error" do
+      assert capture_log(fn ->
+               assert {:error, :invalid_process_name} =
+                        Xogmios.ChainSync.call("invalid process name", :test_message)
+             end) =~ "Invalid process name"
+    end
+
     test "works with global named processes" do
       opts = [
         url: @ws_url,

--- a/test/support/chain_sync/test_handler.ex
+++ b/test/support/chain_sync/test_handler.ex
@@ -60,6 +60,11 @@ defmodule ChainSync.TestHandler do
   end
 
   @impl true
+  def websocket_handle(_message, state) do
+    {:ok, state}
+  end
+
+  @impl true
   def terminate(_arg1, _arg2, _arg3) do
     :ok
   end


### PR DESCRIPTION
Adds support for sending synchronous messages to the ChainSync process.

```elixir
defmodule ChainSyncCounter do
  use Xogmios, :chain_sync

  def start_link(opts) do
    initial_state = [block_count: 0, sync_from: :origin]
    opts = Keyword.merge(opts, initial_state)
    Xogmios.start_chain_sync_link(__MODULE__, opts)
  end

  # Returns the current number of blocks synced
  def get_block_count(pid \\ __MODULE__) do
    # Pull data
    Xogmios.ChainSync.call(pid, :get_block_count)
  end

  @impl true
  def handle_info({:get_block_count, caller, _ref}, state) do
    send(caller, {:ok, state.block_count})
    {:ok, state}
  end

  @impl true
  def handle_block(_block, %{block_count: block_count} = state) do
    # Push data
    {:ok, :next_block, %{state | block_count: block_count + 1}}
  end
end
```

This enables ChainSync clients to be used as part of [GenStage](https://hexdocs.pm/gen_stage/GenStage.html) pipelines by fixing the impedance mismatch between pull-based GenStage demand and push-based data streams.