### PR TITLE
sync_from now accepts tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Current tip information is now included in the block data passed to `handle_block/2` under the `current_tip` key. This allows clients to calculate the time needed for chainsync to sync from the current position. Adding this to the existing block for now to quickly enable other features, but we should consider implementing a new callback (like `handle_forward/2`) to better handle a new top level entity with both "block" and "tip" as properties.
 
+- New syntax for setting an intersection point on `ChainSync`:
+
+  ```
+  sync_from: {slot, block_hash}
+  ```
+
+### Deprecated
+
+- The following syntax for setting an intersection point on `ChainSync` is deprecated:
+
+  ```
+  sync_from: %{
+    point: %{slot: slot, id: block_hash}
+  }
+  ```
+
 ## [v0.6.1](https://github.com/wowica/xogmios/releases/tag/v0.6.1) (2024-12-22)
 
 ### Fixed

--- a/examples/chain_sync_client.ex
+++ b/examples/chain_sync_client.ex
@@ -21,12 +21,7 @@ defmodule ChainSyncClient do
     ### from different points of the chain:
     # initial_state = [sync_from: :babbage]
     # initial_state = [
-    #   sync_from: %{
-    #     point: %{
-    #       slot: 114_127_654,
-    #       id: "b0ff1e2bfc326a7f7378694b1f2693233058032bfb2798be2992a0db8b143099"
-    #     }
-    #   }
+    #   sync_from: {114_127_654, "b0ff1e2bfc326a7f7378694b1f2693233058032bfb2798be2992a0db8b143099"}
     # ]
     opts = Keyword.merge(opts, initial_state)
     Xogmios.start_chain_sync_link(__MODULE__, opts)

--- a/lib/xogmios.ex
+++ b/lib/xogmios.ex
@@ -65,17 +65,12 @@ defmodule Xogmios do
   an atom to `sync_from` only works when connecting with **mainnet**. For testnet, `sync_from`
   must receive a specific point in the chain as described below.
 
-  b) A point in the chain, given its `slot` and `id`. For example:
+  b) A point in the chain using a tuple of `slot` and `block_hash`. For example:
 
   ```elixir
   def start_link(opts) do
     initial_state = [
-      sync_from: %{
-        point: %{
-          slot: 114_127_654,
-          id: "b0ff1e2bfc326a7f7378694b1f2693233058032bfb2798be2992a0db8b143099"
-        }
-      }
+      sync_from: {114_127_654, "b0ff1e2bfc326a7f7378694b1f2693233058032bfb2798be2992a0db8b143099"}
     ]
     opts = Keyword.merge(opts, initial_state)
     Xogmios.start_chain_sync_link(__MODULE__, opts)

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -191,7 +191,21 @@ defmodule Xogmios.ChainSync do
               # No option passed, sync with current tip
               Messages.find_intersection(tip["slot"], tip["id"])
 
-            %{point: point} ->
+            {slot, block_hash} ->
+              Messages.find_intersection(slot, block_hash)
+
+            %{point: point} when is_map(point) ->
+              Logger.warning(
+                "\nThe following syntax is deprecated:\n\n" <>
+                  "sync_from: %{\n" <>
+                  "  point: %{\n" <>
+                  "    slot: #{point.slot},\n" <>
+                  "    id: #{point.id}\n" <>
+                  "  }\n" <>
+                  "}\n\nTo set an intersection point use a tuple as follows:\n\n" <>
+                  "  sync_from: {#{point.slot}, #{point.id}}\n"
+              )
+
               # Sync with a specific point
               Messages.find_intersection(point.slot, point.id)
 


### PR DESCRIPTION
Tuple should be in the format `{slot, block_hash}`. Old syntax is now deprecated.