### PR TITLE
Fix Warning inside the generated `ChainSyncClient` module

### DIFF
--- a/lib/mix/tasks/xogmios.gen.client.ex
+++ b/lib/mix/tasks/xogmios.gen.client.ex
@@ -103,7 +103,6 @@ defmodule Mix.Tasks.Xogmios.Gen.Client do
 
       def start(_type, _args) do
         children = [
-          ...,
           {<%= @app_module_name %>.<%= @client_module_name %>, url: System.fetch_env!("OGMIOS_URL")}
         ]
         ...


### PR DESCRIPTION
There's a warning on the generated `ChainSyncClient` module.

<img width="469" height="227" alt="Image" src="https://github.com/user-attachments/assets/d3c1321a-8251-4f9e-8f07-1976920e74df" />

It is caused by the 10th line, as the 3 dots (...) are not being recognised inside the comment block.

<img width="676" height="408" alt="Image" src="https://github.com/user-attachments/assets/d633cc51-5780-4622-9144-60354709a355" />

Related to https://github.com/wowica/xogmios/issues/60