### PR TITLE
Fix spec warning on ChainSync.call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.1](https://github.com/wowica/xogmios/releases/tag/v0.7.1) (2025-07-16)
+
+### Fixed
+
+- Fixed a spec warning on `Xogmios.ChainSync.call/2` function.
+
 ## [v0.7.0](https://github.com/wowica/xogmios/releases/tag/v0.7.0) (2025-07-11)
 
 ### Fixed

--- a/lib/xogmios/chain_sync.ex
+++ b/lib/xogmios/chain_sync.ex
@@ -121,7 +121,7 @@ defmodule Xogmios.ChainSync do
   This function is useful to send messages to the ChainSync process from outside
   of the ChainSync module. The message should be handled by a matching `c:handle_info/2` callback.
   """
-  @spec call(pid(), term()) :: {:ok, term()} | {:error, term()}
+  @spec call(pid() | atom(), term()) :: {:ok, term()} | {:error, term()}
   def call(pid, message) do
     case get_ws_pid(pid) do
       {:ok, ws_pid} ->


### PR DESCRIPTION
warning would show on LSP when this function was called with a module name instead of a pid