### PR TITLE
Add HTTP support for State Query protocol (#51)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,4 @@
 import Config
 
 config :xogmios, Xogmios.HealthCheck, http_client: Xogmios.HealthCheck.HTTPClientMock
+config :xogmios, Xogmios.StateQuery.HTTP, http_client: Xogmios.HTTP.ClientMock

--- a/examples/http_client.ex
+++ b/examples/http_client.ex
@@ -1,0 +1,89 @@
+defmodule HTTPClient do
+  @moduledoc """
+  This module demonstrates the stateless HTTP API for simple state query operations.
+
+  Unlike the WebSocket examples (state_query_client.ex, chain_sync_client.ex),
+  this doesn't require starting processes or managing supervision trees.
+  """
+
+  alias Xogmios.HTTP
+
+  @doc """
+  Get current epoch via HTTP (stateless)
+  """
+  def get_current_epoch(base_url \\ "http://localhost:1337") do
+    HTTP.send_query(base_url, "epoch")
+  end
+
+  @doc """
+  Get era start information via HTTP
+  """
+  def get_era_start(base_url \\ "http://localhost:1337") do
+    HTTP.send_query(base_url, "eraStart")
+  end
+
+  @doc """
+  Get current block height via HTTP
+  """
+  def get_block_height(base_url \\ "http://localhost:1337") do
+    HTTP.send_query(base_url, "queryNetwork/blockHeight")
+  end
+
+  @doc """
+  Get protocol parameters via HTTP
+  """
+  def get_protocol_parameters(base_url \\ "http://localhost:1337") do
+    HTTP.send_query(base_url, "protocolParameters")
+  end
+
+  @doc """
+  Get UTXOs for specific addresses via HTTP
+  """
+  def get_utxos_by_addresses(addresses, base_url \\ "http://localhost:1337") do
+    HTTP.send_query(base_url, "utxo", %{addresses: addresses})
+  end
+
+  @doc """
+  Demo function showing all HTTP state query operations
+  """
+  def demo(base_url \\ "http://localhost:1337") do
+    IO.puts("Testing Xogmios HTTP State Queries at #{base_url}")
+    IO.puts("")
+
+    IO.puts("State Queries:")
+
+    case get_current_epoch(base_url) do
+      {:ok, epoch} -> IO.puts("Current epoch: #{epoch}")
+      {:error, error} -> IO.puts("Epoch error: #{inspect(error)}")
+    end
+
+    case get_block_height(base_url) do
+      {:ok, %{"quantity" => height, "unit" => unit}} ->
+        IO.puts("Block height: #{height} #{unit}")
+
+      {:ok, result} ->
+        IO.puts("Block height: #{inspect(result)}")
+
+      {:error, error} ->
+        IO.puts("Block height error: #{inspect(error)}")
+    end
+
+    case get_era_start(base_url) do
+      {:ok, era_start} -> IO.puts("Era start: #{inspect(era_start)}")
+      {:error, error} -> IO.puts("Era start error: #{inspect(error)}")
+    end
+
+    case get_protocol_parameters(base_url) do
+      {:ok, params} ->
+        IO.puts("Protocol parameters loaded: #{map_size(params)} parameters")
+        IO.puts("Max block size: #{get_in(params, ["maxBlockBodySize", "bytes"])} bytes")
+        IO.puts("Min fee coefficient: #{params["minFeeCoefficient"]}")
+
+      {:error, error} ->
+        IO.puts("Protocol parameters error: #{inspect(error)}")
+    end
+
+    IO.puts("")
+    IO.puts("Demo completed!")
+  end
+end

--- a/lib/xogmios.ex
+++ b/lib/xogmios.ex
@@ -27,9 +27,9 @@ defmodule Xogmios do
   """
 
   alias Xogmios.ChainSync
+  alias Xogmios.MempoolTxs
   alias Xogmios.StateQuery
   alias Xogmios.TxSubmission
-  alias Xogmios.MempoolTxs
 
   @doc """
   Starts a new State Query process linked to the current process.

--- a/lib/xogmios/chain_sync/connection.ex
+++ b/lib/xogmios/chain_sync/connection.ex
@@ -5,8 +5,8 @@ defmodule Xogmios.ChainSync.Connection do
   """
   require Logger
 
-  alias Xogmios.HealthCheck
   alias Xogmios.ChainSync.Messages
+  alias Xogmios.HealthCheck
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/xogmios/chain_sync/messages.ex
+++ b/lib/xogmios/chain_sync/messages.ex
@@ -11,7 +11,7 @@ defmodule Xogmios.ChainSync.Messages do
   Once the response from this initial message is received, then
   the client proceeds with the appropriate syncing strategy.
   """
-  def initial_sync() do
+  def initial_sync do
     # The `id:"initial_sync"` is returned as part of the message response,
     # and helps the client determine that this is a "nextBlock" response
     # to the initial message.
@@ -31,7 +31,7 @@ defmodule Xogmios.ChainSync.Messages do
   Request first block which preceeds the initial rollback received
   as a response from Ogmios.
   """
-  def next_block_start() do
+  def next_block_start do
     json = ~S"""
     {
       "jsonrpc": "2.0",
@@ -47,7 +47,7 @@ defmodule Xogmios.ChainSync.Messages do
   @doc """
   Request next block.
   """
-  def next_block() do
+  def next_block do
     json = ~S"""
     {
       "jsonrpc": "2.0",

--- a/lib/xogmios/http.ex
+++ b/lib/xogmios/http.ex
@@ -1,0 +1,27 @@
+defmodule Xogmios.HTTP do
+  @moduledoc """
+  Convenience module that provides access to all stateless HTTP APIs.
+
+  This module serves as a unified entry point for users who want to use
+  Xogmios in a stateless manner via HTTP instead of WebSocket connections.
+  """
+  alias Xogmios.StateQuery.HTTP
+
+  @doc """
+  Sends a state query via HTTP.
+
+  This function is stateless and doesn't require a running process.
+
+  ## Examples
+
+      iex> Xogmios.HTTP.send_query("http://localhost:1337", "epoch")
+      {:ok, 450}
+
+      iex> Xogmios.HTTP.send_query("http://localhost:1337", "utxo", %{addresses: ["addr1..."]})
+      {:ok, [%{"transaction" => %{...}, "output" => %{...}}]}
+  """
+  @spec send_query(String.t(), String.t(), map()) :: {:ok, term()} | {:error, term()}
+  def send_query(base_url, query, params \\ %{}) do
+    HTTP.send_query(base_url, query, params)
+  end
+end

--- a/lib/xogmios/mempool/messages.ex
+++ b/lib/xogmios/mempool/messages.ex
@@ -5,7 +5,7 @@ defmodule Xogmios.Mempool.Messages do
 
   alias Jason.DecodeError
 
-  def acquire_mempool() do
+  def acquire_mempool do
     json = ~S"""
     {
       "jsonrpc": "2.0",

--- a/lib/xogmios/state_query/http.ex
+++ b/lib/xogmios/state_query/http.ex
@@ -38,13 +38,11 @@ defmodule Xogmios.StateQuery.HTTP do
   end
 
   defp build_query_message(query_name, query_params) do
-    try do
-      {scope, name} = parse_query_name(query_name)
-      message = Messages.build_message(scope, name, query_params)
-      {:ok, message}
-    rescue
-      error -> {:error, {:build_message_error, error}}
-    end
+    {scope, name} = parse_query_name(query_name)
+    message = Messages.build_message(scope, name, query_params)
+    {:ok, message}
+  rescue
+    error -> {:error, {:build_message_error, error}}
   end
 
   defp parse_query_name(query_name) do

--- a/lib/xogmios/state_query/http.ex
+++ b/lib/xogmios/state_query/http.ex
@@ -1,0 +1,113 @@
+defmodule Xogmios.StateQuery.HTTP do
+  @moduledoc """
+  Stateless HTTP client for State Query protocol.
+
+  This module provides a simpler alternative to the WebSocket-based API
+  for one-off queries without maintaining persistent connections.
+  """
+
+  alias Xogmios.StateQuery.Messages
+  alias Xogmios.StateQuery.Response
+
+  @http_client :httpc
+  @request_timeout 30_000
+  @valid_scopes ["queryNetwork", "queryLedgerState"]
+
+  @doc """
+  Sends a State Query via HTTP and returns a response.
+
+  This function is stateless and doesn't require a running process.
+
+  Support for all [Ledger-state](https://ogmios.dev/mini-protocols/local-state-query/#ledger-state)
+  and [Network](https://ogmios.dev/mini-protocols/local-state-query/#network) queries.
+
+  For Ledger-state queries, only the name of the query is needed. For example:
+  - `send_query(url, "epoch")` is the same as `send_query(url, "queryLedgerState/epoch")`
+
+  For Network queries, the prefix "queryNetwork/" is needed:
+  - `send_query(url, "queryNetwork/blockHeight")`
+  """
+  def send_query(base_url, query, params \\ %{}) do
+    url = parse_url(base_url)
+
+    with {:ok, message} <- build_query_message(query, params),
+         {:ok, response_body} <- http_request(url, message),
+         {:ok, %Response{} = response} <- parse_response(response_body) do
+      {:ok, response.result}
+    end
+  end
+
+  defp build_query_message(query_name, query_params) do
+    try do
+      {scope, name} = parse_query_name(query_name)
+      message = Messages.build_message(scope, name, query_params)
+      {:ok, message}
+    rescue
+      error -> {:error, {:build_message_error, error}}
+    end
+  end
+
+  defp parse_query_name(query_name) do
+    case String.split(query_name, "/") do
+      [scope, name] when scope in @valid_scopes -> {scope, name}
+      [name] -> {"queryLedgerState", name}
+      _ -> raise ArgumentError, "Invalid query name: #{query_name}"
+    end
+  end
+
+  defp parse_url(url) do
+    url
+    |> String.trim_trailing("/")
+    |> replace_protocol()
+  end
+
+  defp replace_protocol(url) do
+    url
+    |> String.replace_prefix("ws://", "http://")
+    |> String.replace_prefix("wss://", "https://")
+  end
+
+  defp http_request(url, message) do
+    headers = [
+      {~c"Content-Type", ~c"application/json"},
+      {~c"Accept", ~c"application/json"}
+    ]
+
+    case client().request(
+           :post,
+           {String.to_charlist(url), headers, ~c"application/json", message},
+           [timeout: @request_timeout],
+           []
+         ) do
+      {:ok, {{_, 200, _}, _headers, body}} ->
+        {:ok, body}
+
+      {:ok, {{_, status_code, _}, _headers, body}} ->
+        {:error, {:http_error, status_code, body}}
+
+      {:error, reason} ->
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  defp parse_response(body) do
+    case Jason.decode(body) do
+      {:ok, %{"result" => result}} ->
+        {:ok, %Response{result: result}}
+
+      {:ok, %{"error" => error}} ->
+        {:error, error}
+
+      {:ok, unexpected} ->
+        {:error, {:unexpected_response, unexpected}}
+
+      {:error, reason} ->
+        {:error, {:decode_error, reason}}
+    end
+  end
+
+  defp client do
+    Application.get_env(:xogmios, __MODULE__, [])
+    |> Keyword.get(:http_client, @http_client)
+  end
+end

--- a/lib/xogmios/tx_submission.ex
+++ b/lib/xogmios/tx_submission.ex
@@ -58,14 +58,12 @@ defmodule Xogmios.TxSubmission do
     do: {:ok, Messages.evaluate_tx(cbor)}
 
   defp call(client, message) do
-    try do
-      case GenServer.call(client, {:send, message}, @request_timeout) do
-        {:ok, response} -> {:ok, response}
-        {:error, reason} -> {:error, reason}
-      end
-    catch
-      :exit, {:timeout, _} -> {:error, :timeout}
+    case GenServer.call(client, {:send, message}, @request_timeout) do
+      {:ok, response} -> {:ok, response}
+      {:error, reason} -> {:error, reason}
     end
+  catch
+    :exit, {:timeout, _} -> {:error, :timeout}
   end
 
   defmacro __using__(_opts) do

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -1,0 +1,99 @@
+defmodule Xogmios.HTTPTest do
+  use ExUnit.Case, async: true
+
+  alias Xogmios.StateQuery.HTTP
+
+  describe "Xogmios.HTTP convenience module" do
+    test "send_query/2 returns epoch" do
+      assert {:ok, result} = HTTP.send_query("http://localhost:1337", "epoch")
+
+      assert result == 450
+    end
+
+    test "send_query/2 returns protocol parameters" do
+      assert {:ok, result} = HTTP.send_query("http://localhost:1337", "protocolParameters")
+
+      assert result["minFeeCoefficient"] == 44
+      assert result["maxBlockBodySize"]["bytes"] == 90112
+    end
+
+    test "send_query/2 returns era start" do
+      assert {:ok, result} = HTTP.send_query("http://localhost:1337", "eraStart")
+
+      assert result["time"] == "2017-09-23T21:44:51Z"
+      assert result["slot"] == 0
+      assert result["epoch"] == 0
+    end
+
+    test "send_query/3 with params returns UTXOs" do
+      params = %{addresses: ["addr1_test"]}
+      assert {:ok, result} = HTTP.send_query("http://localhost:1337", "utxo", params)
+
+      assert is_list(result)
+      assert length(result) == 1
+
+      utxo = List.first(result)
+      assert utxo["transaction"]["id"] == "def456"
+      assert utxo["output"]["address"] == "addr1_test"
+    end
+
+    test "send_query/2 with network query" do
+      assert {:ok, result} = HTTP.send_query("http://localhost:1337", "queryNetwork/blockHeight")
+
+      assert result["quantity"] == 9_876_543
+      assert result["unit"] == "block"
+    end
+  end
+
+  describe "URL handling" do
+    test "converts WebSocket URLs to HTTP" do
+      ws_result = HTTP.send_query("ws://localhost:1337", "epoch")
+      http_result = HTTP.send_query("http://localhost:1337", "epoch")
+
+      assert ws_result == http_result
+      assert {:ok, 450} = ws_result
+    end
+
+    test "handles URLs with trailing slashes" do
+      assert {:ok, 450} = HTTP.send_query("http://localhost:1337/", "epoch")
+    end
+
+    test "converts wss to https" do
+      assert {:ok, 450} = HTTP.send_query("wss://remote.example.com", "epoch")
+    end
+  end
+
+  describe "error handling" do
+    test "handles connection errors" do
+      assert {:error, {:request_failed, _reason}} =
+               HTTP.send_query("http://localhost:9999", "trigger_connection_error")
+    end
+
+    test "handles HTTP error status codes" do
+      assert {:error, {:http_error, 500, _body}} =
+               HTTP.send_query("http://localhost:1337", "trigger_http_error")
+    end
+
+    test "handles JSON-RPC errors" do
+      assert {:error, %{"code" => -32602, "message" => "Invalid params"}} =
+               HTTP.send_query("http://localhost:1337", "trigger_jsonrpc_error")
+    end
+
+    test "handles JSON decode errors" do
+      assert {:error, {:decode_error, _reason}} =
+               HTTP.send_query("http://localhost:1337", "trigger_decode_error")
+    end
+
+    test "handles unexpected JSON response" do
+      assert {:error, {:unexpected_response, unexpected}} =
+               HTTP.send_query("http://localhost:1337", "trigger_unexpected_response")
+
+      assert unexpected["method"] == "something"
+    end
+
+    test "handles build message error for invalid query name" do
+      assert {:error, {:build_message_error, _error}} =
+               HTTP.send_query("http://localhost:1337", "queryNetwork/invalid/too/many/parts")
+    end
+  end
+end

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -14,7 +14,7 @@ defmodule Xogmios.HTTPTest do
       assert {:ok, result} = HTTP.send_query("http://localhost:1337", "protocolParameters")
 
       assert result["minFeeCoefficient"] == 44
-      assert result["maxBlockBodySize"]["bytes"] == 90112
+      assert result["maxBlockBodySize"]["bytes"] == 90_112
     end
 
     test "send_query/2 returns era start" do
@@ -75,7 +75,7 @@ defmodule Xogmios.HTTPTest do
     end
 
     test "handles JSON-RPC errors" do
-      assert {:error, %{"code" => -32602, "message" => "Invalid params"}} =
+      assert {:error, %{"code" => -32_602, "message" => "Invalid params"}} =
                HTTP.send_query("http://localhost:1337", "trigger_jsonrpc_error")
     end
 

--- a/test/support/http/client_mock.ex
+++ b/test/support/http/client_mock.ex
@@ -1,0 +1,60 @@
+defmodule Xogmios.HTTP.ClientMock do
+  def request(:post, {_url, _headers, _content_type, body}, _options, []) do
+    cond do
+      String.contains?(body, "epoch") ->
+        response_body = ~s({"jsonrpc":"2.0","result":450})
+        {:ok, {{nil, 200, nil}, [], response_body}}
+
+      String.contains?(body, "blockHeight") ->
+        response_body = ~s({"jsonrpc":"2.0","result":{"quantity":9876543,"unit":"block"}})
+        {:ok, {{nil, 200, nil}, [], response_body}}
+
+      String.contains?(body, "protocolParameters") ->
+        response_body =
+          ~s({"jsonrpc":"2.0","result":{"minFeeCoefficient":44,"maxBlockBodySize":{"bytes":90112},"minUtxoDepositConstant":{"ada":{"lovelace":0}}}})
+
+        {:ok, {{nil, 200, nil}, [], response_body}}
+
+      String.contains?(body, "utxo") ->
+        response_body =
+          ~s({"jsonrpc":"2.0","result":[{"transaction":{"id":"def456"},"output":{"address":"addr1_test","value":{"ada":{"lovelace":2000000}}}}]})
+
+        {:ok, {{nil, 200, nil}, [], response_body}}
+
+      String.contains?(body, "eraStart") ->
+        response_body =
+          ~s({"jsonrpc":"2.0","result":{"time":"2017-09-23T21:44:51Z","slot":0,"epoch":0}})
+
+        {:ok, {{nil, 200, nil}, [], response_body}}
+
+      String.contains?(body, "trigger_http_error") ->
+        response_body =
+          ~s({"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}})
+
+        {:ok, {{nil, 500, nil}, [], response_body}}
+
+      String.contains?(body, "trigger_jsonrpc_error") ->
+        response_body =
+          ~s({"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}})
+
+        {:ok, {{nil, 200, nil}, [], response_body}}
+
+      String.contains?(body, "trigger_connection_error") ->
+        {:error,
+         {:failed_connect,
+          [{:to_address, {~c"localhost", 9999}}, {:inet, [:inet], :econnrefused}]}}
+
+      String.contains?(body, "trigger_decode_error") ->
+        invalid_json = ~s({"jsonrpc":"2.0","result":invalid_json})
+        {:ok, {{nil, 200, nil}, [], invalid_json}}
+
+      String.contains?(body, "trigger_unexpected_response") ->
+        unexpected_json = ~s({"jsonrpc":"2.0","id":"test","method":"something"})
+        {:ok, {{nil, 200, nil}, [], unexpected_json}}
+
+      true ->
+        response_body = ~s({"jsonrpc":"2.0","result":"default_response"})
+        {:ok, {{nil, 200, nil}, [], response_body}}
+    end
+  end
+end

--- a/test/support/http/client_mock.ex
+++ b/test/support/http/client_mock.ex
@@ -1,60 +1,89 @@
 defmodule Xogmios.HTTP.ClientMock do
+  @moduledoc """
+  Mock HTTP client for testing Xogmios JSON-RPC API interactions.
+
+  This module provides a mock implementation of HTTP requests that simulates
+  various responses from the Xogmios API, including successful responses for
+  different query types and error conditions for testing error handling.
+  """
+
+  @doc """
+  Handles mock HTTP POST requests based on request body content.
+
+  Returns different responses based on keywords found in the request body.
+  """
   def request(:post, {_url, _headers, _content_type, body}, _options, []) do
-    cond do
-      String.contains?(body, "epoch") ->
-        response_body = ~s({"jsonrpc":"2.0","result":450})
-        {:ok, {{nil, 200, nil}, [], response_body}}
-
-      String.contains?(body, "blockHeight") ->
-        response_body = ~s({"jsonrpc":"2.0","result":{"quantity":9876543,"unit":"block"}})
-        {:ok, {{nil, 200, nil}, [], response_body}}
-
-      String.contains?(body, "protocolParameters") ->
-        response_body =
-          ~s({"jsonrpc":"2.0","result":{"minFeeCoefficient":44,"maxBlockBodySize":{"bytes":90112},"minUtxoDepositConstant":{"ada":{"lovelace":0}}}})
-
-        {:ok, {{nil, 200, nil}, [], response_body}}
-
-      String.contains?(body, "utxo") ->
-        response_body =
-          ~s({"jsonrpc":"2.0","result":[{"transaction":{"id":"def456"},"output":{"address":"addr1_test","value":{"ada":{"lovelace":2000000}}}}]})
-
-        {:ok, {{nil, 200, nil}, [], response_body}}
-
-      String.contains?(body, "eraStart") ->
-        response_body =
-          ~s({"jsonrpc":"2.0","result":{"time":"2017-09-23T21:44:51Z","slot":0,"epoch":0}})
-
-        {:ok, {{nil, 200, nil}, [], response_body}}
-
-      String.contains?(body, "trigger_http_error") ->
-        response_body =
-          ~s({"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}})
-
-        {:ok, {{nil, 500, nil}, [], response_body}}
-
-      String.contains?(body, "trigger_jsonrpc_error") ->
-        response_body =
-          ~s({"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}})
-
-        {:ok, {{nil, 200, nil}, [], response_body}}
-
-      String.contains?(body, "trigger_connection_error") ->
-        {:error,
-         {:failed_connect,
-          [{:to_address, {~c"localhost", 9999}}, {:inet, [:inet], :econnrefused}]}}
-
-      String.contains?(body, "trigger_decode_error") ->
-        invalid_json = ~s({"jsonrpc":"2.0","result":invalid_json})
-        {:ok, {{nil, 200, nil}, [], invalid_json}}
-
-      String.contains?(body, "trigger_unexpected_response") ->
-        unexpected_json = ~s({"jsonrpc":"2.0","id":"test","method":"something"})
-        {:ok, {{nil, 200, nil}, [], unexpected_json}}
-
-      true ->
-        response_body = ~s({"jsonrpc":"2.0","result":"default_response"})
-        {:ok, {{nil, 200, nil}, [], response_body}}
-    end
+    body
+    |> detect_request_type()
+    |> build_response()
   end
+
+  def request(method, _request, _options, _profile) do
+    {:error, {:unsupported_method, method}}
+  end
+
+  defp detect_request_type(body) do
+    keywords = [
+      {"epoch", :epoch},
+      {"blockHeight", :block_height},
+      {"protocolParameters", :protocol_parameters},
+      {"utxo", :utxo},
+      {"eraStart", :era_start},
+      {"trigger_http_error", :trigger_http_error},
+      {"trigger_jsonrpc_error", :trigger_jsonrpc_error},
+      {"trigger_connection_error", :trigger_connection_error},
+      {"trigger_decode_error", :trigger_decode_error},
+      {"trigger_unexpected_response", :trigger_unexpected_response}
+    ]
+
+    keywords
+    |> Enum.find_value(:default, fn {keyword, type} ->
+      if String.contains?(body, keyword), do: type
+    end)
+  end
+
+  defp build_response(:epoch), do: success_response(epoch_response())
+  defp build_response(:block_height), do: success_response(block_height_response())
+  defp build_response(:protocol_parameters), do: success_response(protocol_parameters_response())
+  defp build_response(:utxo), do: success_response(utxo_response())
+  defp build_response(:era_start), do: success_response(era_start_response())
+  defp build_response(:trigger_http_error), do: error_response(jsonrpc_error_response(), 500)
+  defp build_response(:trigger_jsonrpc_error), do: success_response(jsonrpc_error_response())
+  defp build_response(:trigger_connection_error), do: connection_error()
+  defp build_response(:trigger_decode_error), do: success_response(invalid_json_response())
+  defp build_response(:trigger_unexpected_response), do: success_response(unexpected_response())
+  defp build_response(:default), do: success_response(default_response())
+
+  defp success_response(body), do: {:ok, {{nil, 200, nil}, [], body}}
+  defp error_response(body, status), do: {:ok, {{nil, status, nil}, [], body}}
+
+  defp connection_error do
+    {:error,
+     {:failed_connect, [{:to_address, {~c"localhost", 9999}}, {:inet, [:inet], :econnrefused}]}}
+  end
+
+  defp epoch_response, do: ~s({"jsonrpc":"2.0","result":450})
+
+  defp block_height_response,
+    do: ~s({"jsonrpc":"2.0","result":{"quantity":9876543,"unit":"block"}})
+
+  defp protocol_parameters_response do
+    ~s({"jsonrpc":"2.0","result":{"minFeeCoefficient":44,"maxBlockBodySize":{"bytes":90112},"minUtxoDepositConstant":{"ada":{"lovelace":0}}}})
+  end
+
+  defp utxo_response do
+    ~s({"jsonrpc":"2.0","result":[{"transaction":{"id":"def456"},"output":{"address":"addr1_test","value":{"ada":{"lovelace":2000000}}}}]})
+  end
+
+  defp era_start_response,
+    do: ~s({"jsonrpc":"2.0","result":{"time":"2017-09-23T21:44:51Z","slot":0,"epoch":0}})
+
+  defp jsonrpc_error_response,
+    do: ~s({"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}})
+
+  defp invalid_json_response, do: ~s({"jsonrpc":"2.0","result":invalid_json})
+
+  defp unexpected_response, do: ~s({"jsonrpc":"2.0","id":"test","method":"something"})
+
+  defp default_response, do: ~s({"jsonrpc":"2.0","result":"default_response"})
 end

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -24,7 +24,7 @@ defmodule TestServer do
     {:ok, cowboy_server}
   end
 
-  def shutdown() do
+  def shutdown do
     Plug.Cowboy.shutdown(WebSocket.Router.HTTP)
   end
 end


### PR DESCRIPTION
## Context

Added HTTP support for the State Query protocol (#51), allowing users to perform stateless state queries without needing persistent WebSocket connections. This makes the lib more accessible for simpler use cases and apps that prefer HTTP communication.

## What’s new?

* Added `StateQuery.HTTP` module for stateless HTTP queries
* Added `Xogmios.HTTP` convenience module as a unified entry point
* Implemented support for ledger-state and network queries
* Added HTTP usage example showing all available ops
* Built a full test suite w/ mocks + error handling
* Added automatic conversion from WebSocket URLs to HTTP URLs

## Screencast


https://github.com/user-attachments/assets/5b476467-0e8d-4edb-99a1-bbf8c5a190f2